### PR TITLE
Optimization: remove read/write from SPI device and return SPI bus on context manager enter

### DIFF
--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -51,45 +51,13 @@ class SPIDevice:
         self.chip_select = chip_select
         self.chip_select.switch_to_output(value=True)
 
-    def read(self, buffer, **kwargs):
-        """
-        Read into ``buffer`` from the device. The number of bytes read will be the
-        length of ``buffer``.
-
-        If ``start`` or ``end`` is provided, then the buffer will be sliced
-        as if ``buffer[start:end]``. This will not cause an allocation like
-        ``buffer[start:end]`` will so it saves memory.
-
-             :param bytearray buffer: buffer to write into
-             :param int start: Index to start writing at
-             :param int end: Index to write up to but not include
-        """
-        self.spi.read(buffer, **kwargs)
-
-    def write(self, buffer, **kwargs):
-        """
-        Write the bytes from ``buffer`` to the device. Transmits a stop bit if
-        ``stop`` is set.
-
-        If ``start`` or ``end`` is provided, then the buffer will be sliced
-        as if ``buffer[start:end]``. This will not cause an allocation like
-        ``buffer[start:end]`` will so it saves memory.
-
-          :param bytearray buffer: buffer containing the bytes to write
-          :param int start: Index to start writing from
-          :param int end: Index to read up to but not include
-          :param bool stop: If true, output an I2C stop condition after the
-                            buffer is written
-        """
-        self.spi.write(buffer, **kwargs)
-
     def __enter__(self):
         while not self.spi.try_lock():
             pass
         self.spi.configure(baudrate=self.baudrate, polarity=self.polarity,
                            phase=self.phase)
         self.chip_select.value = False
-        return self
+        return self.spi
 
     def __exit__(self, *exc):
         self.chip_select.value = True


### PR DESCRIPTION
Since these functions just pass through to the SPI bus, as a small optimization directly return the SPI bus when it's locked.  This removes the need to wrap the functions and the calling overhead.