### PR TITLE
Don't scan the whole bus to verify existence of i2c device

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -52,10 +52,12 @@ class I2CDevice:
         # Verify that a deivce with that address exists.
         while not i2c.try_lock():
             pass
-        scan = i2c.scan()
-        i2c.unlock()
-        if device_address not in scan:
-            raise ValueError("No i2c device at address: " + str(hex(device_address)))
+        try:
+            i2c.writeto(device_address, b'')
+        except OSError:
+            raise ValueError("No I2C device at address: %x" % device_address)
+        finally:
+            i2c.unlock()
 
         self.i2c = i2c
         self.device_address = device_address


### PR DESCRIPTION
Instead of sending an empty write request to every possible address on
the bus to see which devices respond, send it only to the one address
that we are checking. This is not only much faster and more robust
(there might be devices on the bus that respond badly to such requests
at the wrong speed) but also makes it much easier to debug things with a
logic analyzer, as it doesn't get flooded with all those requests.