### PR TITLE
Fix I2C init error on BeagleBone Black

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -64,7 +64,7 @@ class I2CDevice:
         while not i2c.try_lock():
             pass
         try:
-            result = bytearray(2)
+            result = bytearray(1)
             i2c.readfrom_into(device_address, result)
         except OSError:
             raise ValueError("No I2C device at address: %x" % device_address)

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -57,11 +57,11 @@ class I2CDevice:
                 device.write(bytes_read)
     """
     def __init__(self, i2c, device_address):
-        # Verify that a device with that address exists.
+        # write non-zero byte value to verify device exists at address
         while not i2c.try_lock():
             pass
         try:
-            i2c.writeto(device_address, b'')
+            i2c.writeto(device_address, b'x')
         except OSError:
             raise ValueError("No I2C device at address: %x" % device_address)
         finally:

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -57,11 +57,15 @@ class I2CDevice:
                 device.write(bytes_read)
     """
     def __init__(self, i2c, device_address):
-        # write non-zero byte value to verify device exists at address
+        """
+        Try to read a byte from an address,
+        if you get an OSError it means the device is not there
+        """
         while not i2c.try_lock():
             pass
         try:
-            i2c.writeto(device_address, b'x')
+            result = bytearray(2)
+            i2c.readfrom_into(device_address, result)
         except OSError:
             raise ValueError("No I2C device at address: %x" % device_address)
         finally:

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -56,6 +56,7 @@ class I2CDevice:
             with device:
                 device.write(bytes_read)
     """
+
     def __init__(self, i2c, device_address):
         """
         Try to read a byte from an address,
@@ -64,10 +65,15 @@ class I2CDevice:
         while not i2c.try_lock():
             pass
         try:
-            result = bytearray(1)
-            i2c.readfrom_into(device_address, result)
+            i2c.writeto(device_address, b'')
         except OSError:
-            raise ValueError("No I2C device at address: %x" % device_address)
+            # some OS's dont like writing an empty bytesting...
+            # Retry by reading a byte
+            try:
+                result = bytearray(1)
+                i2c.readfrom_into(device_address, result)
+            except OSError:
+                raise ValueError("No I2C device at address: %x" % device_address)
         finally:
             i2c.unlock()
 


### PR DESCRIPTION
This init method verifies that a device exists at the given address.

It was writing a zero byte value to the bus.  This triggered a bug in the Linux kernel I2C bus OMAP2 driver for the BeagleBone. The driver returns an invalid write error when msg->len is 0:
https://github.com/beagleboard/linux/blob/4.14/drivers/i2c/busses/i2c-omap.c#L665

The solution is to write the value 'x' instead of ''.

Refer to Adafruit_Blinka PR #42 for more information:
https://github.com/adafruit/Adafruit_Blinka/pull/42#issuecomment-431948703