### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Adafruit CircuitPython BusDevice
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_BusDevice.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_BusDevice
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_BusDevice.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_BusDevice
     :alt: Build Status
 
 The ``I2CDevice`` and ``SPIDevice`` helper classes make managing transaction state


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.