### PR TITLE
Change stop to False and throw error if True.

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -113,12 +113,11 @@ class I2CDevice:
 
 #pylint: disable-msg=too-many-arguments
     def write_then_readinto(self, out_buffer, in_buffer, *,
-                            out_start=0, out_end=None, in_start=0, in_end=None, stop=True):
+                            out_start=0, out_end=None, in_start=0, in_end=None, stop=False):
         """
         Write the bytes from ``out_buffer`` to the device, then immediately
         reads into ``in_buffer`` from the device. The number of bytes read
         will be the length of ``in_buffer``.
-        Transmits a stop bit after the write, if ``stop`` is set.
 
         If ``out_start`` or ``out_end`` is provided, then the output buffer
         will be sliced as if ``out_buffer[out_start:out_end]``. This will
@@ -136,21 +135,23 @@ class I2CDevice:
         :param int out_end: Index to read up to but not include
         :param int in_start: Index to start writing at
         :param int in_end: Index to write up to but not include
-        :param bool stop: If true, output an I2C stop condition after the buffer is written
+        :param bool stop: Deprecated
         """
         if out_end is None:
             out_end = len(out_buffer)
         if in_end is None:
             in_end = len(in_buffer)
+        if stop:
+            raise ValueError("Stop must be False. Use writeto instead.")
         if hasattr(self.i2c, 'writeto_then_readfrom'):
             # In linux, at least, this is a special kernel function call
             self.i2c.writeto_then_readfrom(self.device_address, out_buffer, in_buffer,
                                            out_start=out_start, out_end=out_end,
-                                           in_start=in_start, in_end=in_end, stop=stop)
+                                           in_start=in_start, in_end=in_end)
 
         else:
             # If we don't have a special implementation, we can fake it with two calls
-            self.write(out_buffer, start=out_start, end=out_end, stop=stop)
+            self.write(out_buffer, start=out_start, end=out_end, stop=False)
             self.readinto(in_buffer, start=in_start, end=in_end)
 
 #pylint: enable-msg=too-many-arguments


### PR DESCRIPTION
It will be removed from libraries and then from here.

This is a breaking API change but is needed to remove stop kwarg from libraries.

See https://github.com/adafruit/circuitpython/issues/2082 for details.