### PR TITLE
Adding ability to skip device probing upon object init.  …

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -35,6 +35,7 @@ class I2CDevice:
 
     :param ~busio.I2C i2c: The I2C bus the device is on
     :param int device_address: The 7 bit device address
+    :param bool probe: Probe for the device upon object creation, default is true
 
     .. note:: This class is **NOT** built into CircuitPython. See
       :ref:`here for install instructions <bus_device_installation>`.
@@ -58,25 +59,9 @@ class I2CDevice:
     """
 
     def __init__(self, i2c, device_address, probe=True):
-        """
-        Try to read a byte from an address,
-        if you get an OSError it means the device is not there
-        """
+
         if probe:
-            while not i2c.try_lock():
-                pass
-            try:
-                i2c.writeto(device_address, b'')
-            except OSError:
-                # some OS's dont like writing an empty bytesting...
-                # Retry by reading a byte
-                try:
-                    result = bytearray(1)
-                    i2c.readfrom_into(device_address, result)
-                except OSError:
-                    raise ValueError("No I2C device at address: %x" % device_address)
-            finally:
-                i2c.unlock()
+            self.__probe_for_device()
 
         self.i2c = i2c
         self.device_address = device_address
@@ -165,3 +150,24 @@ class I2CDevice:
     def __exit__(self, *exc):
         self.i2c.unlock()
         return False
+
+    def __probe_for_device(self):
+        """
+        Try to read a byte from an address,
+        if you get an OSError it means the device is not there 
+        or that the device does not support these means of probing 
+        """
+        while not i2c.try_lock():
+            pass
+        try:
+            i2c.writeto(device_address, b'')
+        except OSError:
+            # some OS's dont like writing an empty bytesting...
+            # Retry by reading a byte
+            try:
+                result = bytearray(1)
+                i2c.readfrom_into(device_address, result)
+            except OSError:
+                raise ValueError("No I2C device at address: %x" % device_address)
+        finally:
+            i2c.unlock()

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -154,8 +154,8 @@ class I2CDevice:
     def __probe_for_device(self):
         """
         Try to read a byte from an address,
-        if you get an OSError it means the device is not there 
-        or that the device does not support these means of probing 
+        if you get an OSError it means the device is not there
+        or that the device does not support these means of probing
         """
         while not self.i2c.try_lock():
             pass

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -60,11 +60,11 @@ class I2CDevice:
 
     def __init__(self, i2c, device_address, probe=True):
 
-        if probe:
-            self.__probe_for_device()
-
         self.i2c = i2c
         self.device_address = device_address
+
+        if probe:
+            self.__probe_for_device()
 
     def readinto(self, buf, **kwargs):
         """
@@ -157,17 +157,17 @@ class I2CDevice:
         if you get an OSError it means the device is not there 
         or that the device does not support these means of probing 
         """
-        while not i2c.try_lock():
+        while not self.i2c.try_lock():
             pass
         try:
-            i2c.writeto(device_address, b'')
+            self.i2c.writeto(self.device_address, b'')
         except OSError:
             # some OS's dont like writing an empty bytesting...
             # Retry by reading a byte
             try:
                 result = bytearray(1)
-                i2c.readfrom_into(device_address, result)
+                self.i2c.readfrom_into(self.device_address, result)
             except OSError:
-                raise ValueError("No I2C device at address: %x" % device_address)
+                raise ValueError("No I2C device at address: %x" % self.device_address)
         finally:
-            i2c.unlock()
+            self.i2c.unlock()

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -57,25 +57,26 @@ class I2CDevice:
                 device.write(bytes_read)
     """
 
-    def __init__(self, i2c, device_address):
+    def __init__(self, i2c, device_address, probe=True):
         """
         Try to read a byte from an address,
         if you get an OSError it means the device is not there
         """
-        while not i2c.try_lock():
-            pass
-        try:
-            i2c.writeto(device_address, b'')
-        except OSError:
-            # some OS's dont like writing an empty bytesting...
-            # Retry by reading a byte
+        if probe:
+            while not i2c.try_lock():
+                pass
             try:
-                result = bytearray(1)
-                i2c.readfrom_into(device_address, result)
+                i2c.writeto(device_address, b'')
             except OSError:
-                raise ValueError("No I2C device at address: %x" % device_address)
-        finally:
-            i2c.unlock()
+                # some OS's dont like writing an empty bytesting...
+                # Retry by reading a byte
+                try:
+                    result = bytearray(1)
+                    i2c.readfrom_into(device_address, result)
+                except OSError:
+                    raise ValueError("No I2C device at address: %x" % device_address)
+            finally:
+                i2c.unlock()
 
         self.i2c = i2c
         self.device_address = device_address


### PR DESCRIPTION
Some hardware devices do not respond to these probes, or could be in reset when software object is created.  Default behavior is the same (probing occurs).