### PR TITLE
Add timeouts to bus devices. 

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -38,9 +38,9 @@ class I2CDevice:
     :param ~busio.I2C i2c: The I2C bus the device is on
     :param int device_address: The 7 bit device address
     :param bool probe: Probe for the device upon object creation, default is true
-    :param int timeout: the amount of time (in milliseconds) to wait before timing out when trying
-        to lock, defaults to 250 milliseconds. to disable any timeout set 'timeout=None'.
-        if the lock times out a RuntimeError will be raised
+    :param int timeout: the amount of time (in seconds) to wait before timing out when trying
+        to lock, defaults to 0.25 seconds. to disable timeout set 'timeout=None'.
+        if the lock times out a RuntimeError will be raised.
 
     .. note:: This class is **NOT** built into CircuitPython. See
       :ref:`here for install instructions <bus_device_installation>`.
@@ -63,7 +63,7 @@ class I2CDevice:
                 device.write(bytes_read)
     """
 
-    def __init__(self, i2c, device_address, probe=True, timeout=250):
+    def __init__(self, i2c, device_address, probe=True, timeout=0.25):
 
         self.i2c = i2c
         self._has_write_read = hasattr(self.i2c, "writeto_then_readfrom")
@@ -172,12 +172,10 @@ class I2CDevice:
     def __enter__(self):
         # pylint: disable-msg=no-member
         if self.timeout is not None:
-            lock_start_time = time.monotonic_ns() // 1000000
+            lock_start_time = time.monotonic()
             while not self.i2c.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
-                    raise RuntimeError(
-                        f"'SPIDevice' lock timed out after {self.timeout} milliseconds"
-                    )
+                    raise RuntimeError(f"'I2CDevice' lock timed out")
         else:
             while not self.i2c.try_lock():
                 pass

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -24,6 +24,7 @@
 `adafruit_bus_device.i2c_device` - I2C Bus Device
 ====================================================
 """
+import time
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git"

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -60,14 +60,14 @@ class I2CDevice:
                 device.write(bytes_read)
     """
 
-    def __init__(self, i2c, device_address, probe=True, timeout=.25):
+    def __init__(self, i2c, device_address, probe=True, timeout=0.25):
 
         self.i2c = i2c
         self._has_write_read = hasattr(self.i2c, "writeto_then_readfrom")
         self.device_address = device_address
-        
+
         self.timeout = timeout
-        
+
         if probe:
             self.__probe_for_device()
 
@@ -167,11 +167,11 @@ class I2CDevice:
     # pylint: enable-msg=too-many-arguments
 
     def __enter__(self):
-       
+
         if self.timeout is not None:
             lock_start_time = time.monotonic()
             while not self.i2c.try_lock():
-                if (self.timeout > (time.monotonic() - lock_start_time)):
+                if self.timeout > (time.monotonic() - lock_start_time):
                     raise Exception("'I2CDevice' lock timed out")
         else:
             while not self.i2c.try_lock():

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -170,6 +170,7 @@ class I2CDevice:
     # pylint: enable-msg=too-many-arguments
 
     def __enter__(self):
+        # pylint: disable-msg=no-member
         if self.timeout is not None:
             lock_start_time = time.monotonic_ns() // 1000000
             while not self.i2c.try_lock():

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -59,12 +59,14 @@ class I2CDevice:
                 device.write(bytes_read)
     """
 
-    def __init__(self, i2c, device_address, probe=True):
+    def __init__(self, i2c, device_address, probe=True, timeout=None):
 
         self.i2c = i2c
         self._has_write_read = hasattr(self.i2c, "writeto_then_readfrom")
         self.device_address = device_address
-
+        
+        self.timeout = timeout
+        
         if probe:
             self.__probe_for_device()
 
@@ -164,8 +166,15 @@ class I2CDevice:
     # pylint: enable-msg=too-many-arguments
 
     def __enter__(self):
-        while not self.i2c.try_lock():
-            pass
+       
+        if self.timeout is not None:
+            lock_start_time = time.monotonic()
+            while not self.i2c.try_lock():
+                if (self.timeout > (time.monotonic() - lock_start_time)):
+                    raise Exception("'I2CDevice' lock timed out")
+        else:
+            while not self.spi.try_lock():
+                pass
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -175,7 +175,7 @@ class I2CDevice:
             lock_start_time = time.monotonic()
             while not self.i2c.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
-                    raise RuntimeError(f"'I2CDevice' lock timed out")
+                    raise RuntimeError("'I2CDevice' lock timed out")
         else:
             while not self.i2c.try_lock():
                 pass

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -174,7 +174,7 @@ class I2CDevice:
                 if (self.timeout > (time.monotonic() - lock_start_time)):
                     raise Exception("'I2CDevice' lock timed out")
         else:
-            while not self.spi.try_lock():
+            while not self.i2c.try_lock():
                 pass
         return self
 

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -171,10 +171,12 @@ class I2CDevice:
 
     def __enter__(self):
         if self.timeout is not None:
-            lock_start_time = time.monotonic_ns()//1000000
+            lock_start_time = time.monotonic_ns() // 1000000
             while not self.i2c.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
-                    raise RuntimeError(f"'SPIDevice' lock timed out after {self.timeout} milliseconds")
+                    raise RuntimeError(
+                        f"'SPIDevice' lock timed out after {self.timeout} milliseconds"
+                    )
         else:
             while not self.i2c.try_lock():
                 pass

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -60,7 +60,7 @@ class I2CDevice:
                 device.write(bytes_read)
     """
 
-    def __init__(self, i2c, device_address, probe=True, timeout=None):
+    def __init__(self, i2c, device_address, probe=True, timeout=.25):
 
         self.i2c = i2c
         self._has_write_read = hasattr(self.i2c, "writeto_then_readfrom")

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -77,7 +77,7 @@ class SPIDevice:
         polarity=0,
         phase=0,
         extra_clocks=0,
-        timeout=.25
+        timeout=0.25
     ):
         self.spi = spi
         self.baudrate = baudrate
@@ -93,7 +93,7 @@ class SPIDevice:
         if self.timeout is not None:
             lock_start_time = time.monotonic()
             while not self.spi.try_lock():
-                if (self.timeout > (time.monotonic() - lock_start_time)):
+                if self.timeout > (time.monotonic() - lock_start_time):
                     raise Exception("'SPIDevice' lock timed out")
         else:
             while not self.spi.try_lock():

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -41,8 +41,9 @@ class SPIDevice:
         DigitalInOut API.
     :param int extra_clocks: The minimum number of clock cycles to cycle the bus after CS is high.
         (Used for SD cards.)
-    :param int timeout: the amount of time (in milliseconds) to wait before timing out when trying
-        to lock, defaults to 250 milliseconds. to disable any timeout set 'timeout=None'.
+    :param int timeout: the amount of time (in seconds) to wait before timing out when trying
+        to lock, defaults to 0.25 seconds. to disable timeout set 'timeout=None'.
+        if the lock times out a RuntimeError will be raised.
 
     .. note:: This class is **NOT** built into CircuitPython. See
       :ref:`here for install instructions <bus_device_installation>`.
@@ -79,7 +80,7 @@ class SPIDevice:
         polarity=0,
         phase=0,
         extra_clocks=0,
-        timeout=250,
+        timeout=0.25,
     ):
         self.spi = spi
         self.baudrate = baudrate
@@ -94,7 +95,7 @@ class SPIDevice:
     def __enter__(self):
         # pylint: disable-msg=no-member
         if self.timeout is not None:
-            lock_start_time = time.monotonic_ns() // 1000000
+            lock_start_time = time.monotonic()
             while not self.spi.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
                     raise RuntimeError("'SPIDevice' lock timed out")

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -76,7 +76,7 @@ class SPIDevice:
         baudrate=100000,
         polarity=0,
         phase=0,
-        extra_clocks=0
+        extra_clocks=0,
         timeout=None
     ):
         self.spi = spi

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -92,6 +92,7 @@ class SPIDevice:
             self.chip_select.switch_to_output(value=True)
 
     def __enter__(self):
+        # pylint: disable-msg=no-member
         if self.timeout is not None:
             lock_start_time = time.monotonic_ns() // 1000000
             while not self.spi.try_lock():

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -97,7 +97,7 @@ class SPIDevice:
             lock_start_time = time.monotonic_ns() // 1000000
             while not self.spi.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
-                    raise RuntimeError(f"'SPIDevice' lock timed out")
+                    raise RuntimeError("'SPIDevice' lock timed out")
         else:
             while not self.spi.try_lock():
                 pass

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -97,9 +97,7 @@ class SPIDevice:
             lock_start_time = time.monotonic_ns() // 1000000
             while not self.spi.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
-                    raise RuntimeError(
-                        f"'SPIDevice' lock timed out after {self.timeout} milliseconds"
-                    )
+                    raise RuntimeError(f"'SPIDevice' lock timed out")
         else:
             while not self.spi.try_lock():
                 pass

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -77,7 +77,7 @@ class SPIDevice:
         polarity=0,
         phase=0,
         extra_clocks=0,
-        timeout=None
+        timeout=.25
     ):
         self.spi = spi
         self.baudrate = baudrate

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -93,10 +93,12 @@ class SPIDevice:
 
     def __enter__(self):
         if self.timeout is not None:
-            lock_start_time = time.monotonic_ns()//1000000
+            lock_start_time = time.monotonic_ns() // 1000000
             while not self.spi.try_lock():
                 if self.timeout > (time.monotonic() - lock_start_time):
-                    raise RuntimeError(f"'SPIDevice' lock timed out after {self.timeout} milliseconds")
+                    raise RuntimeError(
+                        f"'SPIDevice' lock timed out after {self.timeout} milliseconds"
+                    )
         else:
             while not self.spi.try_lock():
                 pass


### PR DESCRIPTION
I noticed that on some devices (so far only nrf52840s) after many reboots all hardware locking hangs indefinitely. This modification adds timeouts to the bus devices (default of .25 seconds to be generous) where it will only try to lock for up to the specified amount of time.  the timeout can be deactivated by passing `None` as the timeout. if the time runs out an exception of type `exception` is thrown.
this code was tested on hardware similar to the feather nrf52840 