### PR TITLE
i2c_device: adjust for removal of stop=, compatibly

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -99,7 +99,10 @@ class I2CDevice:
         :param int end: Index to read up to but not include; if None, use ``len(buf)``
         """
         if stop is not None:
-            print("Warning: deprecated stop= argument specified.  Deprecated. Will be removed in a future release and act as stop=True")
+            print(
+                "Warning: deprecated stop= argument specified.\n"
+                "Will be removed in a future release and act as stop=True"
+            )
         if end is None:
             end = len(buf)
         self.i2c.writeto(self.device_address, buf, start=start, end=end)

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -85,7 +85,7 @@ class I2CDevice:
             end = len(buf)
         self.i2c.readfrom_into(self.device_address, buf, start=start, end=end)
 
-    def write(self, buf, *, start=0, end=None, stop=True):
+    def write(self, buf, *, start=0, end=None, stop=None):
         """
         Write the bytes from ``buffer`` to the device. Transmits a stop bit if
         ``stop`` is set.
@@ -97,11 +97,12 @@ class I2CDevice:
         :param bytearray buffer: buffer containing the bytes to write
         :param int start: Index to start writing from
         :param int end: Index to read up to but not include; if None, use ``len(buf)``
-        :param bool stop: If true, output an I2C stop condition after the buffer is written
         """
+        if stop is not None:
+            print("Warning: deprecated stop= argument specified.  Deprecated. Will be removed in a future release and act as stop=True")
         if end is None:
             end = len(buf)
-        self.i2c.writeto(self.device_address, buf, start=start, end=end, stop=stop)
+        self.i2c.writeto(self.device_address, buf, start=start, end=end)
 
     # pylint: disable-msg=too-many-arguments
     def write_then_readinto(


### PR DESCRIPTION
This version prints (to the serial console) a message about the deprecation.  Then we can remove it *HERE* in a future release.

I can provide a version which just removes it right now, if that's preferable.

Testing performed: with 6.0.0.a2 on an Adafruit Clue, can instantiate the LSM6DS33 object