### PR TITLE
i2c_device: remove write(stop=), write_then_readinto(stop=)

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -62,7 +62,6 @@ class I2CDevice:
     def __init__(self, i2c, device_address, probe=True):
 
         self.i2c = i2c
-        self._has_write_read = hasattr(self.i2c, "writeto_then_readfrom")
         self.device_address = device_address
 
         if probe:
@@ -85,10 +84,10 @@ class I2CDevice:
             end = len(buf)
         self.i2c.readfrom_into(self.device_address, buf, start=start, end=end)
 
-    def write(self, buf, *, start=0, end=None, stop=True):
+    def write(self, buf, *, start=0, end=None):
         """
-        Write the bytes from ``buffer`` to the device. Transmits a stop bit if
-        ``stop`` is set.
+        Write the bytes from ``buffer`` to the device, then transmit a stop
+        bit.
 
         If ``start`` or ``end`` is provided, then the buffer will be sliced
         as if ``buffer[start:end]``. This will not cause an allocation like
@@ -97,11 +96,10 @@ class I2CDevice:
         :param bytearray buffer: buffer containing the bytes to write
         :param int start: Index to start writing from
         :param int end: Index to read up to but not include; if None, use ``len(buf)``
-        :param bool stop: If true, output an I2C stop condition after the buffer is written
         """
         if end is None:
             end = len(buf)
-        self.i2c.writeto(self.device_address, buf, start=start, end=end, stop=stop)
+        self.i2c.writeto(self.device_address, buf, start=start, end=end)
 
     # pylint: disable-msg=too-many-arguments
     def write_then_readinto(
@@ -113,7 +111,6 @@ class I2CDevice:
         out_end=None,
         in_start=0,
         in_end=None,
-        stop=False
     ):
         """
         Write the bytes from ``out_buffer`` to the device, then immediately
@@ -136,30 +133,21 @@ class I2CDevice:
         :param int out_end: Index to read up to but not include; if None, use ``len(out_buffer)``
         :param int in_start: Index to start writing at
         :param int in_end: Index to write up to but not include; if None, use ``len(in_buffer)``
-        :param bool stop: Deprecated
         """
         if out_end is None:
             out_end = len(out_buffer)
         if in_end is None:
             in_end = len(in_buffer)
-        if stop:
-            raise ValueError("Stop must be False. Use writeto instead.")
-        if self._has_write_read:
-            # In linux, at least, this is a special kernel function call
-            self.i2c.writeto_then_readfrom(
-                self.device_address,
-                out_buffer,
-                in_buffer,
-                out_start=out_start,
-                out_end=out_end,
-                in_start=in_start,
-                in_end=in_end,
-            )
 
-        else:
-            # If we don't have a special implementation, we can fake it with two calls
-            self.write(out_buffer, start=out_start, end=out_end, stop=False)
-            self.readinto(in_buffer, start=in_start, end=in_end)
+        self.i2c.writeto_then_readfrom(
+            self.device_address,
+            out_buffer,
+            in_buffer,
+            out_start=out_start,
+            out_end=out_end,
+            in_start=in_start,
+            in_end=in_end,
+        )
 
     # pylint: enable-msg=too-many-arguments
 


### PR DESCRIPTION
Any code that uses the stop= kwarg will get an exception at runtime.  This is the incomptaible alternative compared to #54.

CircuitPython 5.x and 6.x both have writeto_then_readfrom, as does Blinka.  However, this is incompatible with CircuitPython 4. We have previously dropped building the 4.x bundle so this should be OK.

The changes ended up being a bit more extensive.  Testing performed was creating the accelerometer object on an adafruit clue:
```
>>> a = adafruit_lsm6ds.LSM6DS33(board.I2C())
>>> a.acceleration
(-1.04566, -0.34337, -9.60359)
```