### PR TITLE
removed comma on line 113 in i2c_device.py

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -110,7 +110,7 @@ class I2CDevice:
         out_start=0,
         out_end=None,
         in_start=0,
-        in_end=None,
+        in_end=None
     ):
         """
         Write the bytes from ``out_buffer`` to the device, then immediately


### PR DESCRIPTION
This comma was throwing a syntax error for us (python 3.5), removing this comma fixed it