### PR TITLE
Added 0x prefix to i2c addr in "No I2C device at address:" err msg.

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -177,6 +177,6 @@ class I2CDevice:
                 result = bytearray(1)
                 self.i2c.readfrom_into(self.device_address, result)
             except OSError:
-                raise ValueError("No I2C device at address: %x" % self.device_address)
+                raise ValueError("No I2C device at address: 0x%x" % self.device_address)
         finally:
             self.i2c.unlock()

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -177,6 +177,6 @@ class I2CDevice:
                 result = bytearray(1)
                 self.i2c.readfrom_into(self.device_address, result)
             except OSError:
-                raise ValueError("No I2C device at address: 0x%x" % self.device_address)
+                raise ValueError("No I2C device at address: 0x%x" % self.device_address)  # pylint: disable=raise-missing-from
         finally:
             self.i2c.unlock()

--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -177,6 +177,8 @@ class I2CDevice:
                 result = bytearray(1)
                 self.i2c.readfrom_into(self.device_address, result)
             except OSError:
-                raise ValueError("No I2C device at address: 0x%x" % self.device_address)  # pylint: disable=raise-missing-from
+                # pylint: disable=raise-missing-from
+                raise ValueError("No I2C device at address: 0x%x" % self.device_address)
+                # pylint: enable=raise-missing-from
         finally:
             self.i2c.unlock()


### PR DESCRIPTION
Added a '0x' prefix to the i2c address appended to the "No I2C device at address:" error message so that the address is clearly a hexadecimal number.

Change in line 180 of adafruit_bus_device/i2c_device.py,