### PR TITLE
need adafruit-blinka; fix imports

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -10,14 +10,11 @@
 try:
     from typing import Optional, Type
     from types import TracebackType
-    from busio import I2C
-
-    try:
-        from circuitpython_typing import ReadableBuffer, WriteableBuffer
-    except ImportError:
-        from _typing import ReadableBuffer, WriteableBuffer
+    from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError:
     pass
+
+from busio import I2C
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git"

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -12,10 +12,11 @@
 try:
     from typing import Optional, Type
     from types import TracebackType
-    from busio import SPI
-    from digitalio import DigitalInOut
 except ImportError:
     pass
+
+from busio import SPI
+from digitalio import DigitalInOut
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["busio", "digitalio", "circuitpython_typing", "_typing"]
+autodoc_mock_imports = ["busio", "digitalio", "circuitpython_typing"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2020 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+adafruit-blinka


### PR DESCRIPTION
Fixes #77.

Since type annotations were added, we now need `adafruit-blinka` for `circuitpython_typing`. We don't need `_typing` if blinka is up to date. We always need `from busio import I2C`: don't let that fail silently