### PR TITLE
require adafruit-circuitpython-typing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-Adafruit-Blinka
+Adafruit-Blinka>=6.20.4
 adafruit-circuitpython-typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-adafruit-blinka
+Adafruit-Blinka
+adafruit-circuitpython-typing

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka"],
+    install_requires=["Adafruit-Blinka>=6.20.4", "adafruit-circuitpython-typing"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
- Require `adafruit-circuitpython-typing`, in preparation for https://github.com/adafruit/Adafruit_Blinka/pull/556, which removes `circuitpython_typing` from `adafruit-blinka`.
- Require `adafruit-blinka>=6.20.4`, to guarantee that `circuitpython_typing` is available one way or another. After https://github.com/adafruit/Adafruit_Blinka/pull/556, this could be replaced with `adafruit-blinka>=7.0.0`/