### PR TITLE
Require Python version >= 3.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
+    python_requires=">=3.7.0",
     install_requires=["Adafruit-Blinka>=6.20.4", "adafruit-circuitpython-typing"],
     # Choose your license
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
     python_requires=">=3.7.0",
-    install_requires=["Adafruit-Blinka>=6.20.4", "adafruit-circuitpython-typing"],
+    install_requires=["Adafruit-Blinka>=7.0.0", "adafruit-circuitpython-typing"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Spawned from #81, but for using the same Python version as the Blinka requirement of >= 6.20.6