### PR TITLE
Use time.sleep()

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -7,6 +7,8 @@
 ====================================================
 """
 
+import time
+
 try:
     from typing import Optional, Type
     from types import TracebackType
@@ -150,7 +152,7 @@ class I2CDevice:
 
     def __enter__(self) -> "I2CDevice":
         while not self.i2c.try_lock():
-            pass
+            time.sleep(0)
         return self
 
     def __exit__(
@@ -169,7 +171,7 @@ class I2CDevice:
         or that the device does not support these means of probing
         """
         while not self.i2c.try_lock():
-            pass
+            time.sleep(0)
         try:
             self.i2c.writeto(self.device_address, b"")
         except OSError:

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -9,6 +9,8 @@
 ====================================================
 """
 
+import time
+
 try:
     from typing import Optional, Type
     from types import TracebackType
@@ -89,7 +91,7 @@ class SPIDevice:
 
     def __enter__(self) -> SPI:
         while not self.spi.try_lock():
-            pass
+            time.sleep(0)
         self.spi.configure(
             baudrate=self.baudrate, polarity=self.polarity, phase=self.phase
         )


### PR DESCRIPTION
Companion PR to https://github.com/adafruit/Adafruit_CircuitPython_TCA9548A/pull/39 that uses `time.sleep()` to aid in speeding things up if something is being used in a threaded, Blinka environment.