### PR TITLE
Set inital SPI CS value according to parameters

### DIFF
--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -89,7 +89,7 @@ class SPIDevice:
         self.chip_select = chip_select
         self.cs_active_value = cs_active_value
         if self.chip_select:
-            self.chip_select.switch_to_output(value=True)
+            self.chip_select.switch_to_output(value=not self.cs_active_value)
 
     def __enter__(self) -> SPI:
         while not self.spi.try_lock():


### PR DESCRIPTION
The SPIDevice initialization isn't using the passed in cs_active_value flag so for devices that use an active `True` chip select, the bus would be selected when the SPI device object is created rather than when it's used.

