### PR TITLE
try_lock increase wait time from 0 to 1 ms

### DIFF
--- a/adafruit_bus_device/i2c_device.py
+++ b/adafruit_bus_device/i2c_device.py
@@ -151,7 +151,7 @@ class I2CDevice:
 
     def __enter__(self) -> "I2CDevice":
         while not self.i2c.try_lock():
-            time.sleep(0)
+            time.sleep(0.001)
         return self
 
     def __exit__(
@@ -170,7 +170,7 @@ class I2CDevice:
         or that the device does not support these means of probing
         """
         while not self.i2c.try_lock():
-            time.sleep(0)
+            time.sleep(0.001)
         try:
             self.i2c.writeto(self.device_address, b"")
         except OSError:

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -93,7 +93,7 @@ class SPIDevice:
 
     def __enter__(self) -> SPI:
         while not self.spi.try_lock():
-            time.sleep(0)
+            time.sleep(0.001)
         self.spi.configure(
             baudrate=self.baudrate, polarity=self.polarity, phase=self.phase
         )


### PR DESCRIPTION
In the initial code a loop was present inside `I2CDevice.__enter__` and `I2CDevice.__probe_for_device` that was then modified in #91.

I have the issue described in https://github.com/adafruit/Adafruit_CircuitPython_TCA9548A/issues/52: the CPU goes to 100% when the I2C board is not reachable.

Increasing the waiting time from 0 ms to 1 ms decreases the CPU usage of a A64-OLinuXino from 100% to 2%, increasing the battery life during power cuts.

Maybe there is a smarter solution than just increasing the sleep time?

A similar change has also been proposed for the TCA9548A code in https://github.com/adafruit/Adafruit_CircuitPython_TCA9548A/pull/53