### PR TITLE
Avoid SPIDevice init failure in absence of libgpiod bindings

### DIFF
--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -19,7 +19,7 @@ try:
     from busio import SPI
     from digitalio import DigitalInOut
 except ImportError:
-    pass
+    DigitalInOut = None
 
 
 __version__ = "0.0.0+auto.0"


### PR DESCRIPTION
When importing other Adafruit components, I observed this error:

```
[...]
    from adafruit_register.i2c_struct import ROUnaryStruct, UnaryStruct
  File "/opt/measurement_system-venv/lib/python3.9/site-packages/adafruit_register/i2c_struct.py", line 22, in <module>
    from circuitpython_typing.device_drivers import I2CDeviceDriver
  File "/opt/measurement_system-venv/lib/python3.9/site-packages/circuitpython_typing/device_drivers.py", line 13, in <module>
    from adafruit_bus_device.spi_device import SPIDevice
  File "/opt/measurement_system-venv/lib/python3.9/site-packages/adafruit_bus_device/spi_device.py", line 29, in <module>
    class SPIDevice:
  File "/opt/measurement_system-venv/lib/python3.9/site-packages/adafruit_bus_device/spi_device.py", line 76, in SPIDevice
    chip_select: Optional[DigitalInOut] = None,
NameError: name 'DigitalInOut' is not defined
```

This is happening because I did not have the "libgpiod Python bindings" (installable with `pip install gpiod`) and the import here fails:

https://github.com/adafruit/Adafruit_CircuitPython_BusDevice/blob/519bf36d52b302b79ed21bbd64396bd6b45cda4a/adafruit_bus_device/spi_device.py#L20

Causing this line to fail:

https://github.com/adafruit/Adafruit_CircuitPython_BusDevice/blob/519bf36d52b302b79ed21bbd64396bd6b45cda4a/adafruit_bus_device/spi_device.py#L76

This started happening with https://github.com/adafruit/Adafruit_CircuitPython_Typing/pull/42 as it introduced importing `adafruit_bus_device.spi_device.SPIDevice`.